### PR TITLE
Don't crash when author is undefined

### DIFF
--- a/dist/main/index.js
+++ b/dist/main/index.js
@@ -23697,7 +23697,7 @@ const formatCompactLayout = (commit, conclusion, elapsedSeconds) => {
         `${labels} &nbsp; ${process.env.GITHUB_WORKFLOW} [#${process.env.GITHUB_RUN_NUMBER}](${runLink}) ` +
             `(commit [${shortSha}](${commit.html_url}) to branch [${branch}](${branchUrl})) ` +
             `on [${process.env.GITHUB_REPOSITORY}](${repoUrl}) ` +
-            `by [@${author.login}](${author.html_url})`;
+            `by [@${author === null || author === void 0 ? void 0 : author.login}](${author === null || author === void 0 ? void 0 : author.html_url})`;
     return webhookBody;
 };
 exports.formatCompactLayout = formatCompactLayout;

--- a/dist/post/index.js
+++ b/dist/post/index.js
@@ -23697,7 +23697,7 @@ const formatCompactLayout = (commit, conclusion, elapsedSeconds) => {
         `${labels} &nbsp; ${process.env.GITHUB_WORKFLOW} [#${process.env.GITHUB_RUN_NUMBER}](${runLink}) ` +
             `(commit [${shortSha}](${commit.html_url}) to branch [${branch}](${branchUrl})) ` +
             `on [${process.env.GITHUB_REPOSITORY}](${repoUrl}) ` +
-            `by [@${author.login}](${author.html_url})`;
+            `by [@${author === null || author === void 0 ? void 0 : author.login}](${author === null || author === void 0 ? void 0 : author.html_url})`;
     return webhookBody;
 };
 exports.formatCompactLayout = formatCompactLayout;

--- a/src/layouts/compact.ts
+++ b/src/layouts/compact.ts
@@ -32,7 +32,7 @@ export const formatCompactLayout = (
     `${labels} &nbsp; ${process.env.GITHUB_WORKFLOW} [#${process.env.GITHUB_RUN_NUMBER}](${runLink}) ` +
     `(commit [${shortSha}](${commit.html_url}) to branch [${branch}](${branchUrl})) ` +
     `on [${process.env.GITHUB_REPOSITORY}](${repoUrl}) ` +
-    `by [@${author.login}](${author.html_url})`;
+    `by [@${author?.login}](${author?.html_url})`;
 
   return webhookBody;
 };


### PR DESCRIPTION
It crashes for one of our users at the post-job cleanup.
```
Post job cleanup.
...
/home/ec2-user/actions-runner/_work/_actions/reediculous456/ms-teams-deploy-card/v1/dist/post/index.js:23352
            `by [@${author.login}](${author.html_url})`;
                           ^

TypeError: Cannot read properties of null (reading 'login')
    at formatCompactLayout (/home/ec2-user/actions-runner/_work/_actions/reediculous456/ms-teams-deploy-card/v1/dist/post/index.js:23352:28)
    at formatAndNotify (/home/ec2-user/actions-runner/_work/_actions/reediculous456/ms-teams-deploy-card/v1/dist/post/index.js:23690:61)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async Timeout._onTimeout (/home/ec2-user/actions-runner/_work/_actions/reediculous456/ms-teams-deploy-card/v1/dist/post/index.js:35250:13)
```